### PR TITLE
Use project reference over a ref to compiled DLL

### DIFF
--- a/ofrserver/Gateway/Gateway.csproj
+++ b/ofrserver/Gateway/Gateway.csproj
@@ -31,10 +31,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="LibSOE, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\bin\LibSOE.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\Server\LibSOE\LibSOE.csproj">
+      <Project>{2ed6190e-cd8d-47ec-987c-0019bf66a331}</Project>
+      <Name>LibSOE</Name>
+    </ProjectReference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
This fix helps with building using mono libraries and msbuild instead of Visual Studio (for those on Linux).